### PR TITLE
chore: bump @eveshipfit/dogma-engine to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-git",
       "license": "MIT",
       "dependencies": {
-        "@eveshipfit/dogma-engine": "^2.2.0",
+        "@eveshipfit/dogma-engine": "^2.2.1",
         "@eveshipfit/react": "^1.3.0",
         "next": "14.0.1",
         "react": "^18.2.0",
@@ -112,9 +112,9 @@
       }
     },
     "node_modules/@eveshipfit/dogma-engine": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@EVEShipFit/dogma-engine/2.2.0/b046df5fcd9a62235ec11d97678493822f584467",
-      "integrity": "sha512-24m+i/5zltQN2fAdQBXquY0Lqf4inTg4tP1+q1/tjb+3+WL4SBQIs/h+fNgmmuQ6aduJMhhra5QY9VP6hlc8jA==",
+      "version": "2.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@EVEShipFit/dogma-engine/2.2.1/d6113d1fc5acf4a26b5b6e28e7695822bed0ae17",
+      "integrity": "sha512-zkNBf97wQ49HLih4NRRhBg8XpsiYAbIGPNLZqqK3L5YrFAhV2jzNlA0uL4pmIQRUXgSDUvUkHpnLX6L/xjbYHQ==",
       "license": "MIT"
     },
     "node_modules/@eveshipfit/react": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "dependencies": {
     "@eveshipfit/react": "^1.3.0",
-    "@eveshipfit/dogma-engine": "^2.2.0",
+    "@eveshipfit/dogma-engine": "^2.2.1",
     "next": "14.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
* fix: modules that are online (but not active) are contributing to recharge-rate