### PR TITLE
chore: bump @eveshipfit/react and @eveshipfit/dogma-engine to latest

### DIFF
--- a/components/Debug/Debug.module.css
+++ b/components/Debug/Debug.module.css
@@ -15,3 +15,17 @@
 .debugError {
     color: #c84824;
 }
+
+.detail {
+    border: 1px solid #cdcdcd;
+    border-radius: 25px;
+    margin-top: 10px;
+    padding: 20px 0;
+    position: relative;
+}
+
+.detailHeader {
+    display: block;
+    margin-bottom: 10px;
+    text-align: center;
+}

--- a/components/Debug/Debug.tsx
+++ b/components/Debug/Debug.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { useFormatEftToEsi } from "@eveshipfit/react";
+import { CalculationDetail, useFormatEftToEsi } from "@eveshipfit/react";
 import type { EsiFit } from "@eveshipfit/react";
 
 import styles from "./Debug.module.css";
@@ -39,10 +39,20 @@ export const Debug = ({ fit, setFit }: { fit: EsiFit, setFit: (fit: EsiFit) => v
     setError("");
   }
 
-  return <div className={styles.debug}>
-    Still tool is still a work in progress; this textarea allows you, for the time being, to easily import ESI or EFT fits.<br />
-    <textarea className={styles.debugTextArea} value={fitText} onChange={(e) => setFitText(e.target.value)} />
-    <button className={styles.debugButton} onClick={() => formatFit()}>Load Fit</button>
-    <div className={styles.debugError}>{error}</div>
+  return <div>
+    <div className={styles.debug}>
+      Still tool is still a work in progress; this textarea allows you, for the time being, to easily import ESI or EFT fits.<br />
+      <textarea className={styles.debugTextArea} value={fitText} onChange={(e) => setFitText(e.target.value)} />
+      <button className={styles.debugButton} onClick={() => formatFit()}>Load Fit</button>
+      <div className={styles.debugError}>{error}</div>
+    </div>
+    <div className={styles.detail}>
+      <span className={styles.detailHeader}>
+        Detailed calculation information about the ship attributes.
+      </span>
+      <div>
+        <CalculationDetail source="Ship" />
+      </div>
+    </div>
   </div>
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0-git",
       "license": "MIT",
       "dependencies": {
-        "@eveshipfit/dogma-engine": "^2.3.0",
-        "@eveshipfit/react": "^1.9.0",
+        "@eveshipfit/dogma-engine": "^2.3.1",
+        "@eveshipfit/react": "^1.10.0",
         "clsx": "^2.0.0",
         "next": "14.0.1",
         "react": "^18.2.0",
@@ -113,18 +113,18 @@
       }
     },
     "node_modules/@eveshipfit/dogma-engine": {
-      "version": "2.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@EVEShipFit/dogma-engine/2.3.0/0775356d4bb7c13a47f6a189c7a10136486e90d4",
-      "integrity": "sha512-7i7r/3AId3V+k8L1QTVBTHKCuJYHPIWoptt4DNUmmRh8AaABsXhWTGq1rG4sOiw8GeSioRbPoNM/+4w2QaGuQA==",
+      "version": "2.3.1",
+      "resolved": "https://npm.pkg.github.com/download/@EVEShipFit/dogma-engine/2.3.1/b02b1f9d967171e5c5b8e8918b2fdbd1768dff22",
+      "integrity": "sha512-V64pN+s/HmclnVtq0MvxfbHyAEOHq+iae9W95U/LoFsaE+79MaNOHNG9hdEx4L9RI+csZJoDxsV3U/zn/r5WJg==",
       "license": "MIT"
     },
     "node_modules/@eveshipfit/react": {
-      "version": "1.9.0",
-      "resolved": "https://npm.pkg.github.com/download/@eveshipfit/react/1.9.0/1fee874fe673d4d6088d7e93c6bd52ab2796d52d",
-      "integrity": "sha512-L32UMynoeVNzBp3f2rBPj6P2ojxZmkB7v92KECwFZICMUZkxImhwC0/GhtYxwQSz12OdWFOtLvt45ca7Ws+tug==",
+      "version": "1.10.0",
+      "resolved": "https://npm.pkg.github.com/download/@eveshipfit/react/1.10.0/97325828f444200bcaeff4207d9b84a4654d4c52",
+      "integrity": "sha512-yryeRVQMLHjE/tWVFR9MQCowzJOYKOPR8QMPT8pe7/vc5d+hjicrGXdaysvU6s1XsxozWLmYBNS7NZ95UbVEuQ==",
       "license": "MIT",
       "dependencies": {
-        "@eveshipfit/dogma-engine": "^2.3.0",
+        "@eveshipfit/dogma-engine": "^2.3.1",
         "clsx": "^2.0.0",
         "jwt-decode": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "author": "Patric Stout <eveshipfit@truebrain.nl>",
   "license": "MIT",
   "dependencies": {
-    "@eveshipfit/dogma-engine": "^2.3.0",
-    "@eveshipfit/react": "^1.9.0",
+    "@eveshipfit/dogma-engine": "^2.3.1",
+    "@eveshipfit/react": "^1.10.0",
     "clsx": "^2.0.0",
     "next": "14.0.1",
     "react": "^18.2.0",


### PR DESCRIPTION
Additionally, enable a detailed calculation pane, for easier spotting why information is incorrect.

* feat: component to show in detail how attributes were calculated
* fix(ShipStatistics): mass is presented in kg, not the expected tons
* fix: positive stacking penalty calculation is off