### PR TITLE
chore: bump @eveshipfit/react and @eveshipfit/dogma-engine to latest

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -8,14 +8,15 @@
     border-radius: 25px;
     color: #c5c5c5;
     display: flex;
-    margin-top: 10px;
     justify-content: flex-end;
+    margin-top: 10px;
     padding: 20px;
 }
 
 .selection {
     flex: 1;
     margin-top: 10px;
+    overflow-x: hidden;
     padding-right: 10px;
 }
 .selectionHeader {
@@ -50,6 +51,8 @@
 }
 
 .fit {
+    height: 730px;
+    width: 730px;
 }
 
 .statistics {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import clsx from "clsx";
 import React from "react";
 
-import { DogmaEngineProvider, EsiCharacterSelection, EsiProvider, EveDataProvider, HullListing, ShipFitExtended, ShipSnapshotProvider, ShipStatistics } from "@eveshipfit/react";
+import { DogmaEngineProvider, EsiCharacterSelection, EsiProvider, EveDataProvider, HardwareListing, HullListing, ShipFitExtended, ShipSnapshotProvider, ShipStatistics } from "@eveshipfit/react";
 import type { EsiFit } from "@eveshipfit/react";
 
 import { Banner } from "@/components/Banner";
@@ -17,17 +17,6 @@ const Page = () => {
   const [skills, setSkills] = React.useState<Record<string, number>>({});
   const [selection, setSelection] = React.useState<"hulls" | "hardware">("hulls");
 
-  const changeHull = React.useCallback((typeId: number) => {
-    setActiveFit(
-      {
-        "name": "New Ship",
-        "description": "",
-        "ship_type_id": typeId,
-        "items": []
-      }
-    );
-  }, []);
-
   return <ShipSnapshotProvider fit={activeFit} skills={skills}>
     <EsiProvider setSkills={setSkills}>
       <LocationHash setFit={setActiveFit} />
@@ -39,14 +28,14 @@ const Page = () => {
             <div onClick={() => setSelection("hardware")} className={clsx({[styles.selected]: selection == "hardware"})}>Hardware</div>
           </div>
           <div className={clsx(styles.selectionContent, {[styles.collapsed]: selection != "hulls"})}>
-            <HullListing changeHull={changeHull} changeFit={setActiveFit} />
+            <HullListing />
           </div>
           <div className={clsx(styles.selectionContent, {[styles.collapsed]: selection != "hardware"})}>
-            TODO
+            <HardwareListing />
           </div>
         </div>
         <div className={styles.fit}>
-          <ShipFitExtended radius={365} />
+          <ShipFitExtended />
         </div>
         <div className={styles.statistics}>
           <EsiCharacterSelection />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0-git",
       "license": "MIT",
       "dependencies": {
-        "@eveshipfit/dogma-engine": "^2.3.1",
-        "@eveshipfit/react": "^1.10.0",
+        "@eveshipfit/dogma-engine": "^2.3.2",
+        "@eveshipfit/react": "^2.0.0",
         "clsx": "^2.0.0",
         "next": "14.0.1",
         "react": "^18.2.0",
@@ -113,18 +113,18 @@
       }
     },
     "node_modules/@eveshipfit/dogma-engine": {
-      "version": "2.3.1",
-      "resolved": "https://npm.pkg.github.com/download/@EVEShipFit/dogma-engine/2.3.1/b02b1f9d967171e5c5b8e8918b2fdbd1768dff22",
-      "integrity": "sha512-V64pN+s/HmclnVtq0MvxfbHyAEOHq+iae9W95U/LoFsaE+79MaNOHNG9hdEx4L9RI+csZJoDxsV3U/zn/r5WJg==",
+      "version": "2.3.2",
+      "resolved": "https://npm.pkg.github.com/download/@EVEShipFit/dogma-engine/2.3.2/3a01c9aa97817b968215e082f1d54c849cd937e3",
+      "integrity": "sha512-pSv5cowdvU9TfC7TgIoeJ6RsoHf3puEh0hPHA1Tjp+hvQ5qMSphx8wYhZ5RiM92xnVjtkghmAcQ+LnBlAtXBBg==",
       "license": "MIT"
     },
     "node_modules/@eveshipfit/react": {
-      "version": "1.10.0",
-      "resolved": "https://npm.pkg.github.com/download/@eveshipfit/react/1.10.0/97325828f444200bcaeff4207d9b84a4654d4c52",
-      "integrity": "sha512-yryeRVQMLHjE/tWVFR9MQCowzJOYKOPR8QMPT8pe7/vc5d+hjicrGXdaysvU6s1XsxozWLmYBNS7NZ95UbVEuQ==",
+      "version": "2.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@eveshipfit/react/2.0.0/b228ef152770fd54f2fb6e53ed20e93e100a987e",
+      "integrity": "sha512-d6cZAhhjRaAuHjzxzgcUC0Nhie1t+8m/FVs14K1U+G4XD5QMUrY5Ydw7mRe+DkKstJ2O7N52pxsVH6b6UJcqwg==",
       "license": "MIT",
       "dependencies": {
-        "@eveshipfit/dogma-engine": "^2.3.1",
+        "@eveshipfit/dogma-engine": "^2.3.2",
         "clsx": "^2.0.0",
         "jwt-decode": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "author": "Patric Stout <eveshipfit@truebrain.nl>",
   "license": "MIT",
   "dependencies": {
-    "@eveshipfit/dogma-engine": "^2.3.1",
-    "@eveshipfit/react": "^1.10.0",
+    "@eveshipfit/dogma-engine": "^2.3.2",
+    "@eveshipfit/react": "^2.0.0",
     "clsx": "^2.0.0",
     "next": "14.0.1",
     "react": "^18.2.0",


### PR DESCRIPTION
Additionally, enable HardwareListing.

* fix: EffectStopper effect causes a crash
* feat: list all modules for adding them to fits
* feat: ability to remove modules from a fit (via hover on module)
* fix: hull-listing overflows with 5 pixels on the bottom
* fix(ShipSnapshotProvider): React warns about duplicated key in storybook
* chore: refactor hull-listing to use tree-listing
* chore: use Providers to send functions deep into components
* chore: bump @eveshipfit/dogma-engine to 2.3.1
* chore: calculate available slots in ShipSnapshotProvider
* chore: rework ShipFit to use SVGs for better pixel-perfect rendering