### PR TITLE
chore: bump @eveshipfit/react to 2.3.0 and @eveshipfit/dogma-engine to 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0-git",
       "license": "MIT",
       "dependencies": {
-        "@eveshipfit/dogma-engine": "^2.4.0",
-        "@eveshipfit/react": "^2.2.0",
+        "@eveshipfit/dogma-engine": "^2.5.1",
+        "@eveshipfit/react": "^2.3.0",
         "clsx": "^2.0.0",
         "next": "14.0.1",
         "react": "^18.2.0",
@@ -113,22 +113,22 @@
       }
     },
     "node_modules/@eveshipfit/dogma-engine": {
-      "version": "2.4.0",
-      "resolved": "https://npm.pkg.github.com/download/@EVEShipFit/dogma-engine/2.4.0/0ef92814bd21ee643366a7e7456854b6492b1212",
-      "integrity": "sha512-TNv44JY7urfeanLQae4zRvJP0U2g3yvcXAZwQ44F/qbKKavc8WV+F2Umd5ezSs3zxYmcDnHL5byIAQtTNpsvZQ==",
+      "version": "2.5.1",
+      "resolved": "https://npm.pkg.github.com/download/@EVEShipFit/dogma-engine/2.5.1/37f11d3f625573d9812ee28ffa4b85c4b9bbc05d",
+      "integrity": "sha512-J7NxuB3/pYrTcQbraXJPGPtLfUWFRO+UyLZRZNTBvSyyauYVUe9T1m6wfLIIaNYvrdo8nwI9ucicif0oJuOnGw==",
       "license": "MIT"
     },
     "node_modules/@eveshipfit/react": {
-      "version": "2.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@eveshipfit/react/2.2.0/f1e69b500d32c5755ad96cd0d1cd2a188335e165",
-      "integrity": "sha512-hKe3h1nrDMoy834/PkWQZj7aTnXgIzO945lufhNDV9AlSS6n1UQqk2dKpi0hyWT9NImXFGMKuBLXaivHaLxuvg==",
+      "version": "2.3.0",
+      "resolved": "https://npm.pkg.github.com/download/@eveshipfit/react/2.3.0/2acb0f31e55cffaf0f54ab7850de182446186a1e",
+      "integrity": "sha512-gfIaE+cwvUdI+uo9eQiqaTRsADbcC+fDB4IhEESl9mDzs6wlz83BpxN7MHoNtK7zbp9jDRBP14WpxnGFaMFaAg==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "jwt-decode": "^4.0.0"
       },
       "peerDependencies": {
-        "@eveshipfit/dogma-engine": "^2.4.0",
+        "@eveshipfit/dogma-engine": "^2.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "author": "Patric Stout <eveshipfit@truebrain.nl>",
   "license": "MIT",
   "dependencies": {
-    "@eveshipfit/dogma-engine": "^2.4.0",
-    "@eveshipfit/react": "^2.2.0",
+    "@eveshipfit/dogma-engine": "^2.5.1",
+    "@eveshipfit/react": "^2.3.0",
     "clsx": "^2.0.0",
     "next": "14.0.1",
     "react": "^18.2.0",


### PR DESCRIPTION
* feat: show how long it takes for a capacitor to deplete (if not stable)