### PR TITLE
feat: change font to Noto Serif, which somewhat matches the in-game font

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,11 @@ import React from 'react'
 import type { Metadata } from 'next'
 
 import './globals.css'
+import { Noto_Serif } from "next/font/google";
+
+const font = Noto_Serif({
+  subsets: ["latin"],
+});
 
 export const metadata: Metadata = {
   title: 'EVEShip.fit',
@@ -15,7 +20,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className={font.className}>{children}</body>
     </html>
   )
 }


### PR DESCRIPTION
Although the code suggests that we use a font directly from Google Fonts, NextJS is actually privacy-aware, and downloads the font and embeds it locally. So there will not be a fetch to the Google Fonts to serve this font. Read more about this here: https://nextjs.org/docs/pages/building-your-application/optimizing/fonts .

And to leave a bit of history here:

The in-game client uses a font called Eve Sans Neue (as introduced by a very old devblog). This font isn't available in the SDE, and not visible as a TTF in the Client Resources. As such, it stands to reason that it is licensed specifically to CCP for EVE, and not meant as a web-font. Which is not uncommon in the world of fonts.

EVE's webpages use Shentox, which seems similar to Eve Sans Neue. This further reinforces the idea that Eve Sans Neue isn't licensed as a webfont. Shentox however is a paid font, and not cheap. So not going to use that for ESF.

Looking at the resources loaded into the client, there is another font that somewhat looks like Eve Sans Neue: Noto Serif. This font is licensed under the Open License, and available via Google Fonts. As it looks "close enough" to Eve Sans Neue, and given I will not be paying money for Shentox, and Eve Sans Neue seems to not be licensed as a web font, it is the next best thing. At least better than the default font a browser uses.