### PR TITLE
chore: disable StrictMode, as it does more harm than good

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   output: "export",
   distDir: "dist",
+  reactStrictMode: false,
 
   experimental: {
     webpackBuildWorker: true,


### PR DESCRIPTION
For example, swapping modules in StrictMode doesn't work, as it swaps twice, undoing the change.

This only has an impact for development, as StrictMode is always disabled in production.