### PR TITLE
chore: bump all dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "EVEShipFit Team <info@eveship.fit>",
   "license": "MIT",
   "dependencies": {
-    "@eveshipfit/data": "~10.3",
+    "@eveshipfit/data": "~10.4",
     "@eveshipfit/dogma-engine": "7.0.0",
     "@eveshipfit/react": "4.6.0",
     "clsx": "2.1.1",


### PR DESCRIPTION
Can't be pushed till this Tuesday, when TQ syncs with SiSi again.

(this is because the current `data` package is a SiSi one; the postfix got lost while releasing, so it became "latest")